### PR TITLE
disable pip cache when install virtualenv

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -91,7 +91,7 @@
 
 - name: Ensure pip is at the latest version
   shell: >
-    "{{ python_pip_exec_path }}" install pip --upgrade
+    "{{ python_pip_exec_path }}" install pip --upgrade --no-cache-dir
   sudo: yes
   register: pip_upgrade_output
   changed_when: '"""${pip_upgrade_output.stdout}""".find("Requirement already up-to-date") != -1'
@@ -101,6 +101,7 @@
   pip:
     name: virtualenv
     executable: "{{ python_pip_exec_path }}"
+    extra_args: "--no-cache-dir"
   sudo: yes
   when: python_virtualenv_install
 


### PR DESCRIPTION
If pip accidentally downloads a corrupted package, its cache makes it impossible to fix. Running the role second time will not allow a chance to download the package again:

    TASK: [alliedplatform.python3 | Install virtualenv via pip] ******************* 
    failed: [saturn] => {"cmd": "/opt/python/bin/pip3.4 install virtualenv", "failed": true}
    msg: stdout: Collecting virtualenv
      Using cached virtualenv-13.1.0-py2.py3-none-any.whl

    :stderr:   Hash of the package https://pypi.python.org/packages/py2.py3/v/virtualenv/virtualenv-13.1.0-py2.py3-none-any.whl#md5=d57872cd70dcc13f3053418989e973d3 (from https://pypi.python.org/simple/virtualenv/) (a729ef0257b7096a0ef6240327fbb12c) doesn't match the expected hash d57872cd70dcc13f3053418989e973d3!
    Bad md5 hash for package https://pypi.python.org/packages/py2.py3/v/virtualenv/virtualenv-13.1.0-py2.py3-none-any.whl#md5=d57872cd70dcc13f3053418989e973d3 (from https://pypi.python.org/simple/virtualenv/)


    FATAL: all hosts have already failed -- aborting

i.e., cache makes this operation not idempotent. To fix it, `--no-cache-dir` is added to disable pip cache.